### PR TITLE
Fix requirement of fp being file pointer for JSON

### DIFF
--- a/markovchain/storage/json.py
+++ b/markovchain/storage/json.py
@@ -198,14 +198,20 @@ class JsonStorage(Storage):
         fp : `file` or `str`, optional
             Output file (default: stdout).
         """
-        if fp is None:
-            fp = sys.stdout
+
         data = {
             'settings': self.settings,
             'nodes': self.nodes,
             'backward': self.backward
         }
-        json.dump(data, fp, ensure_ascii=False)
+
+        if fp is None:
+            json.dump(data, sys.stdout, ensure_ascii=False)
+        elif isinstance(fp, str):
+            with open(fp, 'w+') as fp2:
+                json.dump(data, fp2, ensure_ascii=False)
+        else:
+            json.dump(data, fp, ensure_ascii=False)
 
     def close(self):
         pass


### PR DESCRIPTION
The documentation states that the JSON storage save can be passed a file name or handle. However, the code does not currently handle the case where a file name is passed. This PR adds code to open the file if the argument passed to `JsonStorage.do_save` is a string.

The code itself is mostly copied from `load`, but with the open flags adjusted accordingly.